### PR TITLE
do not update npm, use version in node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,6 @@ jobs:
       - uses: actions/setup-node@v3.4.1
         with:
           node-version: 20.11.0
-      - name: install npm version
-        run: npm install -g npm
       - name: Get Version
         run: npm -v
       - name: Install modules


### PR DESCRIPTION
### Bug Fixes
- test build failing as it tries to use new major version of npm 