### PR TITLE
Feat/links open in new tabs

### DIFF
--- a/config/heal/home/SlideData.ts
+++ b/config/heal/home/SlideData.ts
@@ -8,9 +8,10 @@ export const slideData = [
     text: 'View newly available datasets',
   },
   {
-    href: '/portal/resource-browser',
+    href: 'https://uc-cdis.github.io/heal-notebooks-pages/',
     icon: IconAnalyses,
     text: 'Explore example analyses!',
+    openInNewWindow: true,
   },
   {
     href: 'https://heal.github.io/platform-documentation/data_sharing_guidance/',

--- a/config/heal/home/SlideData.ts
+++ b/config/heal/home/SlideData.ts
@@ -11,7 +11,7 @@ export const slideData = [
     href: 'https://uc-cdis.github.io/heal-notebooks-pages/',
     icon: IconAnalyses,
     text: 'Explore example analyses!',
-    NewWindow: true,
+    newWindow: true,
   },
   {
     href: 'https://heal.github.io/platform-documentation/data_sharing_guidance/',

--- a/config/heal/home/SlideData.ts
+++ b/config/heal/home/SlideData.ts
@@ -11,7 +11,7 @@ export const slideData = [
     href: 'https://uc-cdis.github.io/heal-notebooks-pages/',
     icon: IconAnalyses,
     text: 'Explore example analyses!',
-    openInNewWindow: true,
+    NewWindow: true,
   },
   {
     href: 'https://heal.github.io/platform-documentation/data_sharing_guidance/',

--- a/config/heal/home/resourceCalloutData.ts
+++ b/config/heal/home/resourceCalloutData.ts
@@ -2,8 +2,14 @@ export const resourceCalloutsData = [
   {
     title: 'Resources for HEAL Investigators',
     links: [
-      { title: 'View the Checklist for HEAL-compliant Data', href: 'https://www.healdatafair.org/resources/road-map' },
-      { title: 'Select a Repository', href: 'https://www.healdatafair.org/resources/guidance/selection' },
+      {
+        title: 'View the Checklist for HEAL-compliant Data',
+        href: 'https://www.healdatafair.org/resources/road-map',
+      },
+      {
+        title: 'Select a Repository',
+        href: 'https://www.healdatafair.org/resources/guidance/selection',
+      },
       {
         title: 'Register Your Study',
         href: 'https://heal.github.io/platform-documentation/study-registration/',
@@ -29,7 +35,7 @@ export const resourceCalloutsData = [
         title: 'Browse All Studies and Data',
         href: '/portal',
       },
-     {
+      {
         title: 'Resources for Secondary Data Users',
         href: '/newly-available-datasets',
       },
@@ -39,7 +45,8 @@ export const resourceCalloutsData = [
       },
       {
         title: 'Explore Example Analyses',
-        href: '/portal/resource-browser',
+        href: 'https://uc-cdis.github.io/heal-notebooks-pages/',
+        NewWindow: true,
       },
       {
         title: 'View Answers to FAQs',

--- a/config/heal/home/resourceCalloutData.ts
+++ b/config/heal/home/resourceCalloutData.ts
@@ -46,7 +46,7 @@ export const resourceCalloutsData = [
       {
         title: 'Explore Example Analyses',
         href: 'https://uc-cdis.github.io/heal-notebooks-pages/',
-        NewWindow: true,
+        newWindow: true,
       },
       {
         title: 'View Answers to FAQs',

--- a/config/heal/navigation.json
+++ b/config/heal/navigation.json
@@ -22,7 +22,8 @@
       {
         "icon": "/icons/HealIcons/Icon-Analyses-Nav.svg",
         "href": "https://uc-cdis.github.io/heal-notebooks-pages/",
-        "name": "Example Analyses"
+        "name": "Example Analyses",
+        "newWindow": true
       },
       {
         "icon": "/icons/HealIcons/Icon-Profile.svg",
@@ -32,7 +33,8 @@
       {
         "icon": "/icons/HealIcons/Icon-Help.svg",
         "href": "https://heal.github.io/platform-documentation/",
-        "name": "Help"
+        "name": "Help",
+        "newWindow": true
       }
     ]
   },

--- a/public/icons/HealIcons/Icon-External-Link.svg
+++ b/public/icons/HealIcons/Icon-External-Link.svg
@@ -1,0 +1,4 @@
+
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="size-4">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+  </svg>

--- a/src/components/ExternalLinkIndicator.stories.tsx
+++ b/src/components/ExternalLinkIndicator.stories.tsx
@@ -3,7 +3,7 @@ import { expect, within } from '@storybook/test';
 import ExternalLinkIndicator from './ExternalLinkIndicator';
 
 const meta = {
-  title: 'HomePage/HealHeader',
+  title: 'components/ExternalLinkIndicator',
   component: ExternalLinkIndicator,
 } satisfies Meta<typeof ExternalLinkIndicator>;
 

--- a/src/components/ExternalLinkIndicator.stories.tsx
+++ b/src/components/ExternalLinkIndicator.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from '@storybook/test';
+import ExternalLinkIndicator from './ExternalLinkIndicator';
+
+const meta = {
+  title: 'HomePage/HealHeader',
+  component: ExternalLinkIndicator,
+} satisfies Meta<typeof ExternalLinkIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByTestId('external-link-indicator'),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByTestId('external-link-indicator-accessible-text'),
+    ).toBeInTheDocument();
+  },
+};

--- a/src/components/ExternalLinkIndicator.tsx
+++ b/src/components/ExternalLinkIndicator.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ExternalLinkSVG from '../../public/icons/HealIcons/Icon-External-Link.svg';
+
+type ExternalLinkIndicatorProps = {
+  className?: string;
+};
+
+const ExternalLinkIndicator: React.FC<ExternalLinkIndicatorProps> = ({
+  className,
+}: ExternalLinkIndicatorProps) => {
+  return (
+    <>
+      <span aria-hidden="true" className={`inline-block ${className}`}>
+        <ExternalLinkSVG />
+      </span>
+      <span className="sr-only">(opens in a new window)</span>
+    </>
+  );
+};
+
+export default ExternalLinkIndicator;

--- a/src/components/ExternalLinkIndicator.tsx
+++ b/src/components/ExternalLinkIndicator.tsx
@@ -10,10 +10,19 @@ const ExternalLinkIndicator: React.FC<ExternalLinkIndicatorProps> = ({
 }: ExternalLinkIndicatorProps) => {
   return (
     <>
-      <span aria-hidden="true" className={`inline-block ${className}`}>
+      <span
+        aria-hidden="true"
+        className={`inline-block ${className}`}
+        data-testid="external-link-indicator"
+      >
         <ExternalLinkSVG />
       </span>
-      <span className="sr-only">(opens in a new window)</span>
+      <span
+        className="sr-only"
+        data-testid="external-link-indicator-accessible-text"
+      >
+        (opens in a new window)
+      </span>
     </>
   );
 };

--- a/src/lib/HealNav/HealHeader.tsx
+++ b/src/lib/HealNav/HealHeader.tsx
@@ -3,7 +3,6 @@ import Image from 'next/image';
 import { Banner, BannerProps, BannerLevelCategories } from '@gen3/frontend';
 import navigationJSON from '../../../config/heal/navigation.json';
 import bannerJSON from '../../../config/heal/banner.json';
-import ArrowIconSVG from '../../../public/icons/HealIcons/Icon-Link-Arrow.svg';
 import ExternalLinkIndicator from '@/components/ExternalLinkIndicator';
 
 const { navigation } = navigationJSON;

--- a/src/lib/HealNav/HealHeader.tsx
+++ b/src/lib/HealNav/HealHeader.tsx
@@ -60,6 +60,8 @@ const HealHeader: React.FC = () => {
                   key={i}
                   href={item.href}
                   className={generateLinkClassNames(i)}
+                  target={item.newWindow ? '_blank' : '_self'}
+                  rel="noopener noreferrer"
                 >
                   <Image
                     src={item.icon}

--- a/src/lib/HealNav/HealHeader.tsx
+++ b/src/lib/HealNav/HealHeader.tsx
@@ -3,6 +3,8 @@ import Image from 'next/image';
 import { Banner, BannerProps, BannerLevelCategories } from '@gen3/frontend';
 import navigationJSON from '../../../config/heal/navigation.json';
 import bannerJSON from '../../../config/heal/banner.json';
+import ArrowIconSVG from '../../../public/icons/HealIcons/Icon-Link-Arrow.svg';
+import ExternalLinkIndicator from '@/components/ExternalLinkIndicator';
 
 const { navigation } = navigationJSON;
 const banners: Array<BannerProps> = [];
@@ -71,6 +73,9 @@ const HealHeader: React.FC = () => {
                     className="mr-2 ml-1 mt-[-2px] h-[16px] lg:ml-4"
                   />
                   {item.name}
+                  {item.newWindow && (
+                    <ExternalLinkIndicator className={'-mt-[3px] ml-1'} />
+                  )}
                 </a>
               ))}
             </div>

--- a/src/lib/Home/Components/CarouselBanner/CarouselBanner.tsx
+++ b/src/lib/Home/Components/CarouselBanner/CarouselBanner.tsx
@@ -51,7 +51,7 @@ const CarouselBanner: React.FC = () => {
             href={obj.href}
             Icon={obj.icon}
             text={obj.text}
-            openInNewWindow={Boolean(obj?.openInNewWindow)}
+            openInNewWindow={Boolean(obj?.NewWindow)}
           />
         ))}
       </div>

--- a/src/lib/Home/Components/CarouselBanner/CarouselBanner.tsx
+++ b/src/lib/Home/Components/CarouselBanner/CarouselBanner.tsx
@@ -51,6 +51,7 @@ const CarouselBanner: React.FC = () => {
             href={obj.href}
             Icon={obj.icon}
             text={obj.text}
+            openInNewWindow={Boolean(obj?.openInNewWindow)}
           />
         ))}
       </div>

--- a/src/lib/Home/Components/CarouselBanner/CarouselBanner.tsx
+++ b/src/lib/Home/Components/CarouselBanner/CarouselBanner.tsx
@@ -51,7 +51,7 @@ const CarouselBanner: React.FC = () => {
             href={obj.href}
             Icon={obj.icon}
             text={obj.text}
-            openInNewWindow={Boolean(obj?.NewWindow)}
+            openInNewWindow={Boolean(obj?.newWindow)}
           />
         ))}
       </div>

--- a/src/lib/Home/Components/CarouselBanner/Slide.tsx
+++ b/src/lib/Home/Components/CarouselBanner/Slide.tsx
@@ -9,6 +9,7 @@ type SlideProps = {
   href: string;
   Icon: React.ElementType<{ className: string }>;
   text: string;
+  openInNewWindow: boolean;
 };
 
 const Slide: React.FC<SlideProps> = ({
@@ -18,6 +19,7 @@ const Slide: React.FC<SlideProps> = ({
   href,
   Icon,
   text,
+  openInNewWindow,
 }: SlideProps) => {
   // Determines the class name based on the current slide index for sliding animation
   const getSlideClassName = (i: number) => {
@@ -38,6 +40,8 @@ const Slide: React.FC<SlideProps> = ({
       <a
         href={href}
         className="text-white flex group text-center mx-1 px-1 hover:underline"
+        target={openInNewWindow ? '_blank' : '_self'}
+        rel="noopener noreferrer"
       >
         <span
           className="

--- a/src/lib/Home/Components/CarouselBanner/Slide.tsx
+++ b/src/lib/Home/Components/CarouselBanner/Slide.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ArrowIconSVG from '../../../../../public/icons/HealIcons/Icon-Arrow.svg';
 import styles from './CarouselAnimations.module.css';
+import ExternalLinkIndicator from '@/components/ExternalLinkIndicator';
 
 type SlideProps = {
   currentSlide: number;
@@ -59,7 +60,11 @@ const Slide: React.FC<SlideProps> = ({
           {text}
         </span>
         <span className="mr-2">
-          <ArrowIconSVG className="inline-block fill-current mt-2" />
+          {openInNewWindow ? (
+            <ExternalLinkIndicator className="mt-[6px] ml-[2px] inline-block" />
+          ) : (
+            <ArrowIconSVG className="inline-block fill-current mt-2" />
+          )}
         </span>
       </a>
     </div>

--- a/src/lib/Home/Components/ResourceCallout/ResourceCallout.tsx
+++ b/src/lib/Home/Components/ResourceCallout/ResourceCallout.tsx
@@ -6,6 +6,8 @@ interface resourceCalloutLink {
   title: string;
   /** Each Link contains a href */
   href: string;
+  /** links can contain openInNewWindow  */
+  NewWindow?: boolean;
 }
 
 interface resourceCalloutProps {
@@ -41,6 +43,8 @@ const ResourceCallout: React.FC<resourceCalloutProps> = ({
                 </span>
                 <a
                   href={resourceLink.href}
+                  target={resourceLink.NewWindow ? '_blank' : '_self'}
+                  rel="noopener noreferrer"
                   className="text-heal-blue underline hover:text-heal-magenta"
                 >
                   {resourceLink.title}

--- a/src/lib/Home/Components/ResourceCallout/ResourceCallout.tsx
+++ b/src/lib/Home/Components/ResourceCallout/ResourceCallout.tsx
@@ -8,7 +8,7 @@ interface resourceCalloutLink {
   /** Each Link contains a href */
   href: string;
   /** links can contain openInNewWindow  */
-  NewWindow?: boolean;
+  newWindow?: boolean;
 }
 
 interface resourceCalloutProps {
@@ -44,12 +44,12 @@ const ResourceCallout: React.FC<resourceCalloutProps> = ({
                 </span>
                 <a
                   href={resourceLink.href}
-                  target={resourceLink.NewWindow ? '_blank' : '_self'}
+                  target={resourceLink.newWindow ? '_blank' : '_self'}
                   rel="noopener noreferrer"
                   className="text-heal-blue underline hover:text-heal-magenta"
                 >
                   {resourceLink.title}
-                  {resourceLink.NewWindow && (
+                  {resourceLink.newWindow && (
                     <ExternalLinkIndicator className="ml-1 -mb-[2px]" />
                   )}
                 </a>

--- a/src/lib/Home/Components/ResourceCallout/ResourceCallout.tsx
+++ b/src/lib/Home/Components/ResourceCallout/ResourceCallout.tsx
@@ -7,7 +7,7 @@ interface resourceCalloutLink {
   title: string;
   /** Each Link contains a href */
   href: string;
-  /** links can contain openInNewWindow  */
+  /** links can contain newWindow to open in new tab  */
   newWindow?: boolean;
 }
 

--- a/src/lib/Home/Components/ResourceCallout/ResourceCallout.tsx
+++ b/src/lib/Home/Components/ResourceCallout/ResourceCallout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import IconLinkArrow from '../../../../../public/icons/HealIcons/Icon-Link-Arrow.svg';
+import ExternalLinkIndicator from '@/components/ExternalLinkIndicator';
 
 interface resourceCalloutLink {
   /** Each Link contains a title */
@@ -48,6 +49,9 @@ const ResourceCallout: React.FC<resourceCalloutProps> = ({
                   className="text-heal-blue underline hover:text-heal-magenta"
                 >
                   {resourceLink.title}
+                  {resourceLink.NewWindow && (
+                    <ExternalLinkIndicator className="ml-1 -mb-[2px]" />
+                  )}
                 </a>
               </li>
             ),


### PR DESCRIPTION
Link to JIRA ticket if there is one:
https://ctds-planx.atlassian.net/browse/HP-2677

**Notes**
* Changes “Explore example analyses” link in rotating carousel to point to new notebook page: https://uc-cdis.github.io/heal-notebooks-pages/  (Link should open in new tab)
* Under “Resources for Secondary Data Users,” points “Explore Example Analyses” link to point to new notebook page: https://uc-cdis.github.io/heal-notebooks-pages/   (Link should open in new tab)
* Example Analyses tab: Link opens in new tab
* Help tab: Link opens in new tab
* New external link indicator added with screen reader accessible text and icon 
 
 Implementation
 <img width="720" height="379" alt="output" src="https://github.com/user-attachments/assets/18821d98-4c5e-4bc2-a0fa-24722a115fd2" />

 Storybook for new component: 
<img width="1283" height="674" alt="image" src="https://github.com/user-attachments/assets/80849ddc-698f-46ae-8ce2-3088f71509ef" />

### New Features
- Adds external link indicator and updates links
